### PR TITLE
Accommodate for discontinued Jenkins builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ After running "Setup Environment" a "plugins" folder and "server" folder will be
 
 >___
 >#### Updating PocketMine-MP
->Occasionally, you may need to update the version of PocketMine-MP your test environment is using. The easiest way to do this is to use the "Update PocketMine-MP" run configuration.  This will remove the current PocketMine-MP server file and replace it with whatever the most current, stable version is on Jenkins.  Optionally, you can manually update the file by downloading a replacement from [Jenkins](https://jenkins.pmmp.io/job/PocketMine-MP/).
+>Occasionally, you may need to update the version of PocketMine-MP your test environment is using. The easiest way to do this is to use the "Update PocketMine-MP" run configuration.  This will remove the current PocketMine-MP server file and replace it with whatever the most current, stable version is on GitHub.  Optionally, you can manually update the file by downloading a replacement from [GitHub Releases](https://github.com/pmmp/PocketMine-MP/releases).
 
 >___
 >#### DeVirion

--- a/UpdatePMMP.php
+++ b/UpdatePMMP.php
@@ -7,7 +7,7 @@ echo("    - Updating PocketMine-MP -\n");
 if(file_exists(getcwd() . "/server/PocketMine-MP.phar")){
     unlink(getcwd() . "/server/PocketMine-MP.phar");
 }
-if(!copy("https://jenkins.pmmp.io/job/PocketMine-MP/lastStableBuild/artifact/PocketMine-MP.phar", getcwd() . "/server/PocketMine-MP.phar")){
+if(!copy("https://github.com/pmmp/PocketMine-MP/releases/latest/download/PocketMine-MP.phar", getcwd() . "/server/PocketMine-MP.phar")){
     throw new \RuntimeException("Failed to download PocketMine-MP.phar");
 }
 echo("    - PocketMine-MP Update Completed -\n");


### PR DESCRIPTION
PMMP no longer uses [Jenkins](https://jenkins.pmmp.io/job/PocketMine-MP/) for PocketMine-MP builds. Instead, they will use the [GitHub Release](https://github.com/pmmp/PocketMine-MP/releases) section of the repository going forward.

In this pull request:
* Updates `README.md` with accurate information
* Updates `UpdatePMMP.php` with new link to latest PHAR

This change has been tested on my machine and works with the latest version of PocketDev.